### PR TITLE
Bugfix refresh respawned player health

### DIFF
--- a/owlProjectZero/Assets/Prefabs/Characters/GroundedEnemy.prefab
+++ b/owlProjectZero/Assets/Prefabs/Characters/GroundedEnemy.prefab
@@ -78,6 +78,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <CONSTANTS>k__BackingField:
+    MAX_HEALTH: 10
     MAX_JUMPS: 0
     MAX_DODGES: 1
     DEAD_DURATION: 3

--- a/owlProjectZero/Assets/Prefabs/Characters/HeavyEnemy.prefab
+++ b/owlProjectZero/Assets/Prefabs/Characters/HeavyEnemy.prefab
@@ -672,6 +672,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <CONSTANTS>k__BackingField:
+    MAX_HEALTH: 15
     MAX_JUMPS: 1
     MAX_DODGES: 0
     DEAD_DURATION: 0

--- a/owlProjectZero/Assets/Prefabs/Characters/MiniBoss.prefab
+++ b/owlProjectZero/Assets/Prefabs/Characters/MiniBoss.prefab
@@ -177,6 +177,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <CONSTANTS>k__BackingField:
+    MAX_HEALTH: 50
     MAX_JUMPS: 1
     MAX_DODGES: 0
     DEAD_DURATION: 1

--- a/owlProjectZero/Assets/Prefabs/Characters/player.prefab
+++ b/owlProjectZero/Assets/Prefabs/Characters/player.prefab
@@ -931,6 +931,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <CONSTANTS>k__BackingField:
+    MAX_HEALTH: 10
     MAX_JUMPS: 3
     MAX_DODGES: 1
     DEAD_DURATION: 3

--- a/owlProjectZero/Assets/Scripts/Character/Character.cs
+++ b/owlProjectZero/Assets/Scripts/Character/Character.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 [System.Serializable]
 public struct CharacterConstants
 {
+    public int MAX_HEALTH;
     public int MAX_JUMPS;
     public int MAX_DODGES;
     public float DEAD_DURATION;

--- a/owlProjectZero/Assets/Scripts/Player/PlayerDead.cs
+++ b/owlProjectZero/Assets/Scripts/Player/PlayerDead.cs
@@ -37,6 +37,8 @@ public class PlayerDead : IState
         player.GetComponent<SpriteRenderer>().color = Color.white;
         player.input.Gameplay.Enable();
         player.dodgeAbility.LeaveDodge();
+        player.healthbar.ResetHealth();
+        player.healthbar.Redraw();
         // Old code
         //player.GetRekt();// Nothing so far
         //SceneManager.LoadScene("SampleScene");


### PR DESCRIPTION
I added the MAX_HEALTH field for all characters, but it's not in-use atm. The healthbar controller script uses it's own max health field and doesn't reference the player's max health.